### PR TITLE
Add thread safety

### DIFF
--- a/lib/rack/crawler_detect.rb
+++ b/lib/rack/crawler_detect.rb
@@ -24,7 +24,7 @@ module Rack
 
       def set_env_variables!(env)
         ua = user_agent(env)
-        return env unless ua
+        return unless ua
         detector = ::CrawlerDetect::Detector.new(ua)
         env["rack.crawler_detect"] = {
           is_crawler:   detector.is_crawler?,

--- a/lib/rack/crawler_detect.rb
+++ b/lib/rack/crawler_detect.rb
@@ -16,29 +16,25 @@ module Rack
     end
 
     def call(env)
-      dup._call(env)
-    end
-
-    def _call(env)
-      @env = env
-      set_env_variables!
-      @app.call(@env)
+      set_env_variables!(env)
+      @app.call(env)
     end
 
     private
 
-      def set_env_variables!
-        return @env unless user_agent
-        detector = ::CrawlerDetect::Detector.new(user_agent)
-        @env["rack.crawler_detect"] = {
+      def set_env_variables!(env)
+        ua = user_agent(env)
+        return env unless ua
+        detector = ::CrawlerDetect::Detector.new(ua)
+        env["rack.crawler_detect"] = {
           is_crawler:   detector.is_crawler?,
           crawler_name: detector.crawler_name,
         }
       end
 
-      def user_agent
+      def user_agent(env)
         user_agent_headers.map do |header|
-          @env[header]
+          env[header]
         end.compact.join(" ")
       end
 

--- a/lib/rack/crawler_detect.rb
+++ b/lib/rack/crawler_detect.rb
@@ -16,6 +16,10 @@ module Rack
     end
 
     def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
       @env = env
       set_env_variables!
       @app.call(@env)

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Rack::CrawlerDetect do
 
   it "should be thread safe" do
      instance = described_class.new(app)
-     instance.call({ "test": true })
+     instance.call({})
      expect(instance.instance_variable_get(:@env)).to be_nil
   end
 

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -31,4 +31,11 @@ RSpec.describe Rack::CrawlerDetect do
     expect(last_request.is_crawler?).to eq(true)
     expect(last_request.crawler_name).to eq("Test Bot")
   end
+
+  it "should be thread safe" do
+     instance = described_class.new(app)
+     instance.call({ "test": true })
+     expect(instance.instance_variable_get(:@env)).to be_nil
+  end
+
 end

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -32,10 +32,4 @@ RSpec.describe Rack::CrawlerDetect do
     expect(last_request.crawler_name).to eq("Test Bot")
   end
 
-  it "should be thread safe" do
-     instance = described_class.new(app)
-     instance.call({})
-     expect(instance.instance_variable_get(:@env)).to be_nil
-  end
-
 end


### PR DESCRIPTION
Close #20 

When using the rack middleware, we noticed weird side effects such as HTTP requests getting the wrong response (from another request)

After a few digging, it appeared this only happened on multi-threaded puma server.

The rack class instance is not thread safe, probably because it stores `@env` as an instance variable. This kind of race condition are difficult to test / reproduce / troubleshoot, but I think what happens is that:
- One request hits the middleware, writes `@env`
- About at the same time, another request come in, overwrite `@env`
- First request somehow provides the wrong `@env` to `@app` 

I removed that `@env` variable to avoid that side effect.