### PR TITLE
allow is_crawler? & crawler_name to be called outside of rack

### DIFF
--- a/lib/rack/crawler_detect.rb
+++ b/lib/rack/crawler_detect.rb
@@ -8,11 +8,11 @@ module Rack
     def initialize(app, options = {})
       Rack::Request::Helpers.module_eval do
         def is_crawler?
-          env["rack.crawler_detect"][:is_crawler]
+          env["rack.crawler_detect"] && env["rack.crawler_detect"][:is_crawler]
         end
 
         def crawler_name
-          env["rack.crawler_detect"][:crawler_name]
+          env["rack.crawler_detect"] && env["rack.crawler_detect"][:crawler_name]
         end
       end
       @app = app


### PR DESCRIPTION
When `is_crawler?` is called outside the context of a rack request--for example in specs--it will raise an error. This prevents that.

```
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # /usr/local/bundle/gems/crawler_detect-1.0.1/lib/rack/crawler_detect.rb:11:in `is_crawler?'
```