### PR TITLE
Moves to Ruby's Stdlib JSON implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     crawler_detect (1.0.2)
-      oj (>= 3.0)
       qonfig (~> 0.24)
 
 GEM
@@ -34,7 +33,6 @@ GEM
     jaro_winkler (1.5.4)
     method_source (1.0.0)
     minitest (5.14.1)
-    oj (3.10.6)
     parallel (1.19.1)
     parallel_tests (2.32.0)
       parallel

--- a/crawler_detect.gemspec
+++ b/crawler_detect.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "oj", ">= 3.0"
   spec.add_dependency "qonfig", "~> 0.24"
 
   spec.add_development_dependency "activesupport", "~> 6.0.3"

--- a/lib/crawler_detect.rb
+++ b/lib/crawler_detect.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "oj"
+require "json"
 require "qonfig"
 
 require_relative "crawler_detect/config"

--- a/lib/crawler_detect/library/loader.rb
+++ b/lib/crawler_detect/library/loader.rb
@@ -6,7 +6,7 @@ module CrawlerDetect
     module Loader
       # Load JSON raw file
       def load_raw(path)
-        ::Oj.load_file(path)
+        JSON.parse(File.read(path))
       end
 
       # Remove cached raw data


### PR DESCRIPTION
This gem uses sub 30 kilobytes of JSON. The performance penalty by using
Ruby's stdlib to parse that amount of JSON compared to using Oj seems fine
if you can save a significant amount of time by not building a native
extension for Oj at bundle time, especially in very small Ruby applications
that depend on this gem, in Docker environments when trying to keep the
image size small, etc.