### PR TITLE
CI: Trust rvm to offer an OK Bundler built-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ os: linux
 dist: xenial
 language: ruby
 cache: bundler
-before_install:
-  - gem install bundler
 env:
   - "TEST_GROUP=1"
   - "TEST_GROUP=2"


### PR DESCRIPTION
This PR tries to simplify the CI configuration by testing a removal.