### PR TITLE
Speed up crawler detection by caching Regexp objects

### DIFF
--- a/lib/crawler_detect.rb
+++ b/lib/crawler_detect.rb
@@ -32,7 +32,7 @@ module CrawlerDetect
     # @param config [Proc]
     def setup!(&config)
       @config = CrawlerDetect::Config.new(&config)
-      Library::DATA_CLASSES.each(&:reload_data)
+      Library.reset_cache
     end
 
     # @since 1.0.0

--- a/lib/crawler_detect/library.rb
+++ b/lib/crawler_detect/library.rb
@@ -5,18 +5,28 @@ module CrawlerDetect
   module Library
     DATA_CLASSES = [Library::Headers, Library::Exclusions, Library::Crawlers].freeze
 
+    @regexp_cache = {}
+
     class << self
       # @param param [String] Name of raw data
       # @return [Regexp]
       def get_regexp(param)
-        data = get_array(param)
-        %r{#{data.join('|')}}i
+        @regexp_cache[param] ||= begin
+          data = get_array(param)
+          %r{#{data.join('|')}}i
+        end
       end
 
       # @param param [String] Name of raw data
       # @return [Array]
       def get_array(param)
         const_get("CrawlerDetect::Library::#{param.capitalize}").send(:data)
+      end
+
+      # @return [void]
+      def reset_cache
+        DATA_CLASSES.each(&:reload_data)
+        @regexp_cache = {}
       end
     end
   end

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Rack::CrawlerDetect do
   end
 
   before do
-    allow(CrawlerDetect::Library::Crawlers).to receive(:data).and_return(["Test Bot"])
+    allow(CrawlerDetect::Library).to receive(:get_regexp).and_call_original
+    allow(CrawlerDetect::Library).to receive(:get_regexp).with("crawlers").and_return(%r{Test Bot}i)
   end
 
   it "extends functionality of Rack::Request" do


### PR DESCRIPTION
Profiling shows that a significant amount of time is spent in `CrawlerDetect::Library.get_regexp` compiling regular expressions. Since the patterns don't change between `is_crawler?` calls, we can cache the Regexp objects and reuse them to achieve a major speedup.

On my laptop, a full test run used to take 22:21, now it takes around 6:43, which is 4.3x faster.