### PR TITLE
Add Ruby 3.4 to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, jruby-9.3, jruby-head]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, jruby-9.3, jruby-head]
         test-group: [1, 2, 3, 4]
     name: Ruby ${{ matrix.ruby }}, test-group ${{ matrix.test-group }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, jruby-9.3, jruby-head]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, jruby-9.3, jruby-9.4]
         test-group: [1, 2, 3, 4]
     name: Ruby ${{ matrix.ruby }}, test-group ${{ matrix.test-group }}
     steps:


### PR DESCRIPTION
## Summary
- test GitHub Actions on Ruby 3.4
- temporary remove jruby-head because of zlib, see https://github.com/ruby/zlib/issues/38#issuecomment-3005644656