### PR TITLE
Remove `.rspec_status` from the gem bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Gemfile.lock
 # .rubocop-https?--*
 
 .idea
+.rspec_status

--- a/crawler_detect.gemspec
+++ b/crawler_detect.gemspec
@@ -15,13 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/loadkpi/crawler_detect"
   spec.license       = "MIT"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir["lib/**/*", "LICENSE.txt", "README.md"].select { |file| File.file?(file) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "qonfig", ">= 0.24"


### PR DESCRIPTION
- Simplify `spec.files` in the gemspec so package includes only required files
- Remove and add `.rspec_status` to `.gitignore` as by accident it was part of the gem

---

Hey there 👋 I was looking at my CI bundle cache size as looking for biggest offenders and noticed that this gem adds unnecessary 17MB rspec status file - seems it was added by accident in #57